### PR TITLE
fix(workflows): pin govulncheck to v1.1.4 SHA and replace actionlint placeholder

### DIFF
--- a/.github/workflows/actions-pin-lint.yml
+++ b/.github/workflows/actions-pin-lint.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: install actionlint
         run: |
-          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/<SHA-of-v1.7.12>/scripts/download-actionlint.bash) 1.7.12
+          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/914e7df21a07ef503a81201c76d2b11c789d3fca/scripts/download-actionlint.bash) 1.7.12
       - name: actionlint
         run: ./actionlint -color

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -30,7 +30,7 @@ jobs:
           go-version: ${{ inputs.go-version }}
           cache: true
       - name: install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@d1f380186385b4f64e00313f31743df8e4b89a77 # v1.1.4
       - name: govulncheck
         working-directory: ${{ inputs.working-directory }}
         run: govulncheck ${{ inputs.patterns }}


### PR DESCRIPTION
## Summary

- Pin `govulncheck` to `v1.1.4` via commit SHA — `@latest` (v1.3.0+) requires Go 1.25.0+, but callers run on Go 1.24 with `GOTOOLCHAIN=local`, causing every consumer job to fail with `requires go >= 1.25.0`.
- Replace the literal `<SHA-of-v1.7.12>` placeholder in `actions-pin-lint.yml` with the actual `rhysd/actionlint@v1.7.12` commit SHA (`914e7df21a07ef503a81201c76d2b11c789d3fca`). The placeholder shipped as-is, so the installer URL 404'd and the workflow failed with `./actionlint: No such file or directory`.

## Failing CI evidence

Reproduced on [gr1m0h/vimpin#11](https://github.com/gr1m0h/vimpin/pull/11):
- `govulncheck` job: `golang.org/x/vuln/cmd/govulncheck@latest: golang.org/x/vuln@v1.3.0 requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)`
- `actions-pin-lint` job: `SHA-of-v1.7.12: No such file or directory` → `./actionlint: No such file or directory`

## Notes

- `v1.1.4` is the last `golang.org/x/vuln` release built on `go 1.22.0`, so it stays compatible with the workflow's default `go-version: "1.24"` input.
- `go install` accepts commit SHAs (normalized to a pseudo-version internally), keeping the pin consistent with the SHA-pin convention used for `uses:` entries in this repo.

## Test plan

- [ ] Re-run the failing jobs on `gr1m0h/vimpin#11` after callers bump their `@<sha>` reference to this PR's merge commit.
- [ ] Confirm `govulncheck` install succeeds and reports vulnerabilities (or clean) against the target module.
- [ ] Confirm `actionlint` installer downloads and the lint step runs.