### PR TITLE
fix(templates): rename caller job IDs to match required status contexts

### DIFF
--- a/templates/caller-go.yml.template
+++ b/templates/caller-go.yml.template
@@ -9,7 +9,7 @@ permissions:
 jobs:
   govulncheck:
     uses: gr1m0h/.github/.github/workflows/govulncheck.yml@<tag>
-  osv-scanner:
+  osv-scan:
     uses: gr1m0h/.github/.github/workflows/osv-scanner.yml@<tag>
     permissions:
       contents: read
@@ -28,5 +28,5 @@ jobs:
       contents: read
       security-events: write
       actions: read
-  actions-pin-lint:
+  actionlint:
     uses: gr1m0h/.github/.github/workflows/actions-pin-lint.yml@<tag>

--- a/templates/caller-node.yml.template
+++ b/templates/caller-node.yml.template
@@ -9,7 +9,7 @@ permissions:
 jobs:
   npm-audit:
     uses: gr1m0h/.github/.github/workflows/npm-audit.yml@<tag>
-  osv-scanner:
+  osv-scan:
     uses: gr1m0h/.github/.github/workflows/osv-scanner.yml@<tag>
     permissions:
       contents: read
@@ -28,5 +28,5 @@ jobs:
       contents: read
       security-events: write
       actions: read
-  actions-pin-lint:
+  actionlint:
     uses: gr1m0h/.github/.github/workflows/actions-pin-lint.yml@<tag>


### PR DESCRIPTION
## Summary

- Rename caller job IDs in `templates/caller-go.yml.template` and `templates/caller-node.yml.template`:
  - `osv-scanner:` → `osv-scan:` (produces context `osv-scan / osv-scan`)
  - `actions-pin-lint:` → `actionlint:` (produces context `actionlint / actionlint`)

## Why

GitHub composes the status-check context for reusable-workflow jobs as `{caller-job-id} / {callee-job-id}`. The standard ruleset applied to target repos requires contexts named `osv-scan / osv-scan` and `actionlint / actionlint`, but the templates shipped the caller IDs as `osv-scanner` and `actions-pin-lint`. Adopters end up with contexts `osv-scanner / osv-scan` and `actions-pin-lint / actionlint`, so required checks never resolve and PRs stay blocked on:

> Expected — Waiting for status to be reported

Observed on `gr1m0h/vimpin#11`, which had to patch the caller IDs locally as a workaround. Fixing the templates removes the need for that workaround on future adopters.

## Test plan

- [ ] After merge, regenerate or copy `caller-go.yml.template` into `gr1m0h/vimpin` and confirm required checks `osv-scan / osv-scan` and `actionlint / actionlint` resolve.
- [ ] Same verification with a Node consumer of `caller-node.yml.template`.