### PR TITLE
fix(files-apply): use App bot identity for sync commits

### DIFF
--- a/.github/workflows/files-apply.yml
+++ b/.github/workflows/files-apply.yml
@@ -39,11 +39,21 @@ jobs:
       - name: render and PR files into target repos
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
           UPSTREAM_REF: ${{ github.sha }}
         run: |
           set -euo pipefail
           owner=gr1m0h
           workdir=$(pwd)
+
+          # Resolve the bot identity of the App that minted GH_TOKEN so
+          # commits are authored as "<slug>[bot]" with the App bot's
+          # numeric id baked into a stable noreply email. Without this we
+          # would fall back to a hardcoded name that collides with whoever
+          # happens to own that username on github.com.
+          bot_name="${APP_SLUG}[bot]"
+          bot_id=$(gh api "/users/${bot_name}" --jq '.id')
+          bot_email="${bot_id}+${bot_name}@users.noreply.github.com"
 
           yq -o=json security/baseline.yaml > /tmp/baseline.json
 
@@ -124,8 +134,8 @@ jobs:
                 echo "noop   $repo"; exit 0
               fi
 
-              git config user.email "baseline-bot@users.noreply.github.com"
-              git config user.name  "baseline-bot"
+              git config user.email "$bot_email"
+              git config user.name  "$bot_name"
               git add -A
               git commit -m "chore: sync baseline files from gr1m0h/.github@${UPSTREAM_REF:0:7}"
               git push -f origin "$branch" >/dev/null 2>&1


### PR DESCRIPTION
The previous identity was hardcoded as 'baseline-bot <baseline-bot@users.noreply.github.com>'. The username 'baseline-bot' is already squatted by an unrelated user on github.com (id 159272312), so every sync commit displayed that stranger's avatar and linked back to their profile on every target repo's PR.

Resolve the bot identity from the App that mints GH_TOKEN via the 'app-slug' output of actions/create-github-app-token, then format it as '<slug>[bot]' with the bot user's numeric id embedded in a stable noreply email. The resulting author belongs to the App itself, cannot collide with any human account, and follows the same pattern used by dependabot[bot], github-actions[bot], etc.