### PR TITLE
chore(baseline): add Shell/HCL templates and expand files-apply allowlist

### DIFF
--- a/security/baseline.yaml
+++ b/security/baseline.yaml
@@ -35,6 +35,14 @@ exclude:
 # -----------------------------------------------------------------------------
 files_apply:
   repos:
+    - asdf-act
+    - asdf-k6
+    - asdf-soracom
+    - asdf-starship
+    - asdf-terraformer
+    - asdf-vegeta
+    - k6-ec2
+    - terraform-aws-cloudwatch-dashboard-for-loadtesting
     - vimpin
     - vimpin-action
     - vimpin-renovate-config
@@ -61,6 +69,12 @@ defaults:
     - src: templates/caller-node.yml.template
       dst: .github/workflows/security.yml
       languages: [TypeScript, JavaScript]
+    - src: templates/caller-shell.yml.template
+      dst: .github/workflows/security.yml
+      languages: [Shell]
+    - src: templates/caller-hcl.yml.template
+      dst: .github/workflows/security.yml
+      languages: [HCL]
 
 # -----------------------------------------------------------------------------
 # Per-repo overrides — merged on top of `defaults`.

--- a/templates/caller-hcl.yml.template
+++ b/templates/caller-hcl.yml.template
@@ -1,0 +1,24 @@
+# <target-repo>/.github/workflows/security.yml
+name: security
+on:
+  pull_request:
+  workflow_dispatch:
+permissions:
+  contents: read
+
+jobs:
+  osv-scan:
+    uses: gr1m0h/.github/.github/workflows/osv-scanner.yml@<tag>
+    permissions:
+      contents: read
+      security-events: write
+  gitleaks:
+    uses: gr1m0h/.github/.github/workflows/gitleaks.yml@<tag>
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    uses: gr1m0h/.github/.github/workflows/dependency-review.yml@<tag>
+    permissions:
+      contents: read
+      pull-requests: write
+  actionlint:
+    uses: gr1m0h/.github/.github/workflows/actions-pin-lint.yml@<tag>

--- a/templates/caller-shell.yml.template
+++ b/templates/caller-shell.yml.template
@@ -1,0 +1,24 @@
+# <target-repo>/.github/workflows/security.yml
+name: security
+on:
+  pull_request:
+  workflow_dispatch:
+permissions:
+  contents: read
+
+jobs:
+  osv-scan:
+    uses: gr1m0h/.github/.github/workflows/osv-scanner.yml@<tag>
+    permissions:
+      contents: read
+      security-events: write
+  gitleaks:
+    uses: gr1m0h/.github/.github/workflows/gitleaks.yml@<tag>
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    uses: gr1m0h/.github/.github/workflows/dependency-review.yml@<tag>
+    permissions:
+      contents: read
+      pull-requests: write
+  actionlint:
+    uses: gr1m0h/.github/.github/workflows/actions-pin-lint.yml@<tag>


### PR DESCRIPTION
## Summary

Expand `files-apply` coverage to eight additional repos and add the missing language templates.

### Allowlist additions (`security/baseline.yaml` → `files_apply.repos`)

| Repo | Primary lang |
|---|---|
| `k6-ec2` | Go |
| `asdf-act`, `asdf-k6`, `asdf-soracom`, `asdf-starship`, `asdf-terraformer`, `asdf-vegeta` | Shell |
| `terraform-aws-cloudwatch-dashboard-for-loadtesting` | HCL |

### New caller templates (`defaults.files`)

- `templates/caller-shell.yml.template` (`languages: [Shell]`)
- `templates/caller-hcl.yml.template` (`languages: [HCL]`)

Both templates wire the language-agnostic reusable workflows only:

- `osv-scan` (lockfile scanner — no-op when there is no manifest, harmless)
- `gitleaks`
- `dependency-review`
- `actions-pin-lint`

`govulncheck` / `codeql-go` are intentionally omitted (Go-specific).

The two templates are kept as separate files even though their contents are identical today. The split anticipates future language-specific jobs (ShellCheck for Shell, tflint/tfsec/checkov for HCL) without forcing a later refactor.

## Why

Without this change, the allowlist would only cover the existing three `vimpin*` repos. Adding the new repos without language templates would have been a no-op (files-apply would skip them on language mismatch), leaving the stale `chore/baseline-sync` PRs already present on those repos unfixed.

## Test plan

- [ ] After merge, `files-apply` triggers on `push` (`paths: security/baseline.yaml`, `templates/**`).
- [ ] Confirm each of the 8 new repos gets either a fresh sync commit or a force-pushed `chore/baseline-sync` branch with the App bot identity (`<slug>[bot]`) as the author.
- [ ] Confirm the Shell repos receive `caller-shell.yml.template` content (4 jobs, no govulncheck/codeql).
- [ ] Confirm `terraform-aws-cloudwatch-dashboard-for-loadtesting` receives `caller-hcl.yml.template` content.
- [ ] Confirm `k6-ec2` receives `caller-go.yml.template` content (full Go set).