### PR TITLE
refactor(files-apply): accumulate commits on chore/baseline-sync instead of force-pushing

### DIFF
--- a/.github/workflows/files-apply.yml
+++ b/.github/workflows/files-apply.yml
@@ -1,8 +1,10 @@
 name: files-apply
 # Renders the templates declared in security/baseline.yaml and opens (or
 # updates) a PR in every target repo. Each repo uses a fixed sync branch
-# `chore/baseline-sync`, so re-runs force-push the same branch and refresh the
-# existing PR rather than opening a new one.
+# `chore/baseline-sync`. Re-runs check out that branch (or create it from
+# the default branch on first run) and append a new commit when the
+# rendered output drifts, so any manual fixes already pushed onto the PR
+# are preserved instead of being clobbered by a force-push.
 #
 # Required permissions on the GitHub App's target installations:
 #   contents:        write   (push branches)
@@ -107,6 +109,11 @@ jobs:
               fi
 
               # Clone target and prepare the sync branch.
+              #
+              # We accumulate commits on `chore/baseline-sync` rather than
+              # force-pushing, so manual fixes pushed onto the open PR
+              # (e.g. a Go toolchain bump applied alongside the synced
+              # workflow) survive subsequent baseline rebuilds.
               tmpdir=$(mktemp -d)
               git clone --depth 1 \
                 "https://x-access-token:${GH_TOKEN}@github.com/${owner}/${repo}.git" \
@@ -114,7 +121,19 @@ jobs:
               cd "$tmpdir"
               default_branch=$(git symbolic-ref --short HEAD)
               branch="chore/baseline-sync"
-              git checkout -B "$branch"
+
+              # If the sync branch already exists upstream, check it out as
+              # the working ref so new commits stack on top of whatever the
+              # PR currently has. Otherwise start fresh from the default
+              # branch.
+              if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+                git fetch --depth 1 origin \
+                  "+refs/heads/${branch}:refs/remotes/origin/${branch}" \
+                  >/dev/null 2>&1
+                git checkout -B "$branch" "refs/remotes/origin/${branch}"
+              else
+                git checkout -B "$branch"
+              fi
 
               # Render each template, substituting @<tag> with the upstream commit.
               while IFS= read -r entry; do
@@ -138,7 +157,7 @@ jobs:
               git config user.name  "$bot_name"
               git add -A
               git commit -m "chore: sync baseline files from gr1m0h/.github@${UPSTREAM_REF:0:7}"
-              git push -f origin "$branch" >/dev/null 2>&1
+              git push origin "$branch" >/dev/null 2>&1
 
               # Open the PR if it does not already exist; otherwise the force-push
               # has already refreshed the existing one.
@@ -148,7 +167,7 @@ jobs:
                 gh pr create --repo "$owner/$repo" \
                   --base "$default_branch" --head "$branch" \
                   --title "chore: sync baseline files from gr1m0h/.github" \
-                  --body "Synced from gr1m0h/.github@${UPSTREAM_REF}. This PR is opened automatically by files-apply.yml; each upstream change force-pushes onto this branch, so review the latest diff before merging."
+                  --body "Synced from gr1m0h/.github@${UPSTREAM_REF}. This PR is opened automatically by files-apply.yml; each upstream change appends a new commit to this branch (no force-push), so review the latest commit(s) before merging."
                 echo "create $repo"
               else
                 echo "update $repo  $pr_url"


### PR DESCRIPTION
## Summary

Switch `files-apply.yml` from force-pushing the rendered baseline onto `chore/baseline-sync` to **appending a new commit** when the render drifts.

## Why

Force-push semantics meant any commit a reviewer pushed onto an open `chore/baseline-sync` PR was destroyed the next time files-apply ran. Concretely, the Go 1.25 bump applied on top of the synced workflow on [gr1m0h/vimpin#11](https://github.com/gr1m0h/vimpin/pull/11) kept disappearing every time the baseline was rebuilt, leaving the PR re-broken (govulncheck failing on the unbumped Go version, etc.).

With accumulating commits:

- Each upstream change is a separate commit on the PR — reviewers can see exactly what landed when.
- Manual fixes survive subsequent baseline rebuilds.
- The PR's branch grows monotonically and is linear (no merge commits introduced).

## Behavior diff

| | Before (force-push) | After (accumulate) |
|---|---|---|
| First run | `git checkout -B chore/baseline-sync` from default branch, push -f | Same (branch doesn't exist remotely yet) |
| Subsequent run, no drift | force-push noop | `git status --porcelain` is empty -> exit early, no commit |
| Subsequent run, drift detected | force-push new baseline (clobbers all prior commits) | Append one new commit on top of whatever the PR already has, `git push` (non-force) |
| Manual fix pushed onto the PR | Lost on next sync | Preserved |
| PR closed and branch deleted | Re-created on next sync | Re-created on next sync |

## Implementation notes

- When the sync branch already exists upstream, shallow-fetch it and `git checkout -B chore/baseline-sync refs/remotes/origin/chore/baseline-sync`.
- Drop `-f` from the push. If the remote has advanced past our local HEAD (race with a concurrent manual push) the push will reject loudly instead of overwriting silently; the `|| echo \"FAIL ...\"` wrapper around each repo already handles that as a per-repo failure without aborting the whole run.
- Update the workflow's header comment and the PR creation body so the new semantics are documented at the source of truth.

## Test plan

- [ ] Trigger `files-apply` via `workflow_dispatch` after merge.
- [ ] Confirm vimpin's PR #11 gains a new commit on top of `847c9b5` rather than being force-rebuilt from scratch.
- [ ] Push a throwaway commit onto a target repo's `chore/baseline-sync`, re-run files-apply, and confirm both the throwaway commit and the new sync commit are present.
- [ ] Delete a target repo's `chore/baseline-sync` branch (or its PR), re-run files-apply, confirm the branch is recreated from the default branch.