### PR TITLE
feat: add reusable release-go workflow (tagpr + goreleaser)

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -1,0 +1,86 @@
+name: release-go
+
+# Reusable release pipeline for Go projects.
+#
+# tagpr maintains a "release PR" on every push to main: it tracks the unreleased
+# diff since the last semver tag and, when that PR is merged, tags the merge
+# commit and creates the GitHub Release. The bump is patch by default; add
+# `tagpr:minor` / `tagpr:major` to the release PR to bump. Version selection
+# does NOT parse commit messages, so non-Conventional squash-merge subjects no
+# longer silently skip a release.
+#
+# goreleaser runs as a dependent job in the SAME workflow run, gated on the tag
+# tagpr just created. This deliberately keeps building in one run: a tag pushed
+# with the default GITHUB_TOKEN does NOT trigger a separate tag-triggered
+# workflow (GitHub's recursion guard), so a "push tag -> release" split would
+# need a PAT/App token. Co-locating goreleaser here avoids that.
+#
+# Consumers own their `.goreleaser.yaml`. Because tagpr creates the release,
+# set `release: { mode: append }` there so goreleaser uploads artifacts into
+# the existing release instead of failing on a duplicate.
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: Directory to run goreleaser in (use "." for repo root).
+        type: string
+        default: "."
+      prepare-command:
+        description: >-
+          Optional shell command run (with mise available) before goreleaser,
+          e.g. vendoring generated assets. Runs in working-directory.
+        type: string
+        default: ""
+      goreleaser-version:
+        description: goreleaser binary version constraint passed to goreleaser-action.
+        type: string
+        default: "~> v2"
+
+permissions:
+  contents: read
+
+jobs:
+  tagpr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      tag: ${{ steps.tagpr.outputs.tag }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: Songmu/tagpr@e84001bd5dac8defa0c75b3913937d284a3b3660 # v1.20.0
+        id: tagpr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  goreleaser:
+    needs: tagpr
+    if: needs.tagpr.outputs.tag != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Full history + the tag tagpr just pushed onto this commit, so
+          # goreleaser resolves the version from the tag.
+          fetch-depth: 0
+      - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        with:
+          experimental: true
+      - name: prepare
+        if: inputs.prepare-command != ''
+        working-directory: ${{ inputs.working-directory }}
+        run: ${{ inputs.prepare-command }}
+      - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        with:
+          version: ${{ inputs.goreleaser-version }}
+          args: release --clean
+          workdir: ${{ inputs.working-directory }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What
Go プロジェクト向けの再利用可能リリースワークフロー `release-go.yml`（`on: workflow_call`）を追加。

- job `tagpr`: push→main でリリース PR を維持し、マージでタグ付け＋GitHub Release 作成（bump はラベル制御、デフォルト patch）
- job `goreleaser`: 同一 run 内で `needs: tagpr` + tag 出力ガード。mise セットアップ → 任意の `prepare-command` → `goreleaser release --clean`

## Why
現状、リリース機構が各リポジトリに個別実装されており、squash-merge の subject が Conventional Commit でないと `mathieudutour/github-tag-action` が黙って bump をスキップする事故が発生した（mdv で v0.1.4 が作られなかった）。tagpr はコミットメッセージ解析に依存せず、リリース PR のマージで明示的にリリースを切るため再発しない。security 系ワークフローと同様に共通化し、修正が一箇所で全 Go リポジトリに波及する。

## Design notes
- tagpr がタグを default `GITHUB_TOKEN` で push すると別ワークフローを起動できない（再帰ガード）ため、goreleaser を同一 run の後続 job に同居させ PAT/App トークンを不要にした。
- 固有のビルド前処理（例: mdv の mermaid vendoring）は `prepare-command` 入力で注入する。
- 全 action は SHA ピン留め（`actions-pin-lint` 準拠）。
- consumer は自リポジトリの `.goreleaser.yaml` に `release: { mode: append }` を設定（tagpr が作る Release に成果物を追加するため）。

## Inputs
- `working-directory` (default `.`)
- `prepare-command` (default 空)
- `goreleaser-version` (default `~> v2`)

## First consumer
gr1m0h/mdv（別 PR で薄い caller に置換）

🤖 Generated with [Claude Code](https://claude.com/claude-code)