### PR TITLE
feat(security): add Renovate auto-merge baseline

### DIFF
--- a/security/baseline.yaml
+++ b/security/baseline.yaml
@@ -57,8 +57,15 @@ files_apply:
 # -----------------------------------------------------------------------------
 defaults:
   # Rulesets to apply. Each name must match security/rulesets/<name>.json.
+  #
+  # `main-protection` keeps 0 required approvals (PR + required checks only),
+  # so it never blocks Renovate auto-merge. `require-review` layers the
+  # 1-approval rule back on top and is the default, so human-driven repos
+  # still need a review. Renovate-managed repos (files_apply.repos) drop
+  # `require-review` in their overrides below to allow unattended merges.
   rulesets:
     - main-protection
+    - require-review
 
   # Files to PR into the target repo.
   #
@@ -82,6 +89,12 @@ defaults:
       languages: [HCL]
     - src: templates/CODEOWNERS.template
       dst: CODEOWNERS
+    # Renovate config. `.github` is not in files_apply.repos, so it keeps its
+    # own .github/dependabot.yml; every repo covered here gets Renovate with
+    # minor/patch auto-merge instead. Language-agnostic (Renovate auto-detects
+    # managers), so no `languages` filter.
+    - src: templates/renovate.json.template
+      dst: renovate.json
 
 # -----------------------------------------------------------------------------
 # Per-repo overrides — merged on top of `defaults`.
@@ -102,3 +115,25 @@ repo_overrides:
     rulesets: [main-protection, tag-protection]
   mdv:
     rulesets: [main-protection, tag-protection]
+  # Renovate-managed repos without tag protection. They drop `require-review`
+  # (0 approvals) so minor/patch updates auto-merge once checks pass.
+  asdf-act:
+    rulesets: [main-protection]
+  asdf-k6:
+    rulesets: [main-protection]
+  asdf-soracom:
+    rulesets: [main-protection]
+  asdf-starship:
+    rulesets: [main-protection]
+  asdf-terraformer:
+    rulesets: [main-protection]
+  asdf-vegeta:
+    rulesets: [main-protection]
+  k6-ec2:
+    rulesets: [main-protection]
+  terraform-aws-cloudwatch-dashboard-for-loadtesting:
+    rulesets: [main-protection]
+  vimpin-docs:
+    rulesets: [main-protection]
+  ichiza-docs:
+    rulesets: [main-protection]

--- a/security/rulesets/main-protection.json
+++ b/security/rulesets/main-protection.json
@@ -16,11 +16,11 @@
     {
       "type": "pull_request",
       "parameters": {
-        "required_approving_review_count": 1,
-        "dismiss_stale_reviews_on_push": true,
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
         "require_code_owner_review": false,
         "require_last_push_approval": false,
-        "required_review_thread_resolution": true
+        "required_review_thread_resolution": false
       }
     },
     {

--- a/security/rulesets/require-review.json
+++ b/security/rulesets/require-review.json
@@ -1,0 +1,35 @@
+{
+  "name": "require-review",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    },
+    {
+      "actor_id": 3940641,
+      "actor_type": "Integration",
+      "bypass_mode": "pull_request"
+    }
+  ]
+}

--- a/templates/renovate.json.template
+++ b/templates/renovate.json.template
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "description": "Auto-merge minor and patch updates once required checks pass.",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    }
+  ],
+  "platformAutomerge": true
+}


### PR DESCRIPTION
Split `main-protection` to 0 required approvals so Renovate can auto-merge without bypassing branch protection. A new `require-review` ruleset (1 approval) is added to defaults so human-driven repos still require a review.

Add `renovate.json.template` distributed to all managed repos, enabling minor/patch auto-merge once required checks pass.

Renovate-managed repos (asdf-*, k6-ec2, vimpin-docs, etc.) override rulesets to drop `require-review`, allowing unattended merges.